### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go Testing
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/mcosta74/slogext/security/code-scanning/1](https://github.com/mcosta74/slogext/security/code-scanning/1)

To resolve the issue, add an explicit `permissions` block to the workflow to ensure the GITHUB_TOKEN available to this workflow (and jobs within it) has the least privilege necessary. For build/test workflows like this, that will usually just be `contents: read`.  

The most maintainable way is to add the `permissions` block at the top level (next to `name` and `on`), so it applies to all jobs in this workflow. No changes are needed to individual jobs.  

**Where/What to Edit:**  
- Edit `.github/workflows/test.yml`
- Insert the following block after the `name: Go Testing` line:
  ```yaml
  permissions:
    contents: read
  ```

**No new methods, imports, or variable definitions are necessary.**

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
